### PR TITLE
travis: add Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,20 @@ rust:
 os:
   - linux
   - osx
+  - windows
 
 script:
   - cargo build --release
   - cargo test --release
 
-
 before_deploy:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then python3 gen_artifacts.py --version $TRAVIS_TAG --platform linux-x86_64 ; fi
+
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew bundle ; fi  # install python3
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 gen_artifacts.py --version $TRAVIS_TAG --platform osx ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 gen_artifacts.py --version $TRAVIS_TAG --platform osx; fi
+
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]] ; then choco install python; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]] ; then /c/python37/python --version gen_artifacts.py --version $TRAVIS_TAG --platform windows;fi
 
 deploy:
   skip_cleanup: true


### PR DESCRIPTION
Note publishing releases does not work yet because of:

https://travis-ci.community/t/rvm-command-not-found-when-deploy-to-github-release/367